### PR TITLE
fix: augment `@nuxt/schema` rather than `nuxt/schema`

### DIFF
--- a/src/runtime/index.d.ts
+++ b/src/runtime/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'nuxt/schema' {
+declare module '@nuxt/schema' {
   interface PublicRuntimeConfig {
     tradingview: {
       experimental?: {


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/issues/28332

`nuxt/schema` is a re-export of `@nuxt/schema` for users to use. Modules should not augment it, or it may end up overwriting the inferred types from `@nuxt/schema`.

(We made the change in https://github.com/nuxt/module-builder/pull/295 (released in v0.8.0 of `@nuxt/module-builder`) to avoid doing this in `@nuxt/module-builder` itself.)